### PR TITLE
Retrieve only necessary data from Facebook.

### DIFF
--- a/lib/facelink/client.rb
+++ b/lib/facelink/client.rb
@@ -12,9 +12,9 @@ module Facelink
     def interactions()
       @interactions = []
       posts = graph.get_connections(page_id, "posts", { limit: limit,
-                                                         fields: ["reactions",
-                                                                  "comments",
-                                                                  "type"]})
+                                                        fields: ["reactions{id, type}",
+                                                                 "comments{id}",
+                                                                 "type"]})
 
       posts.each do |post|
         @interactions += reactions(post) + comments(post)


### PR DESCRIPTION
Closes #3.

Avoid unnecessary data and (large requests) to be fetched from Facebook.