### PR TITLE
Remove koala gem as dependency

### DIFF
--- a/bin/facelink
+++ b/bin/facelink
@@ -13,7 +13,7 @@ command :generate do |c|
   c.action do |args, _|
     fail 'You have to specify the filename' unless args.first
 
-    Facelink::Config.configure_facebook_client
+    Facelink::Config.configure_koala_facebook_client
 
     file = File.open(args.first, 'r')
     Facelink::Report.new(file).generate_csv

--- a/facelink.gemspec
+++ b/facelink.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["pedrovitti@gmail.com"]
 
   spec.summary       = "Collect Facebook users interactions with a given Facebook page."
-  spec.homepage      = "https://github.com/pedrovitti/spregen'"
+  spec.homepage      = "https://github.com/pedrovitti/facelink'"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|

--- a/lib/facelink.rb
+++ b/lib/facelink.rb
@@ -1,3 +1,4 @@
 require_relative 'facelink/report.rb'
 require_relative 'facelink/config.rb'
 require_relative 'facelink/client.rb'
+require_relative 'facelink/facebook_client.rb'

--- a/lib/facelink/client.rb
+++ b/lib/facelink/client.rb
@@ -1,7 +1,5 @@
 module Facelink
-
   class Client
-
     attr_accessor :page_id, :limit, :facebook_client
 
     def initialize(page_id, limit = 25, facebook_client)
@@ -10,12 +8,12 @@ module Facelink
       @facebook_client = facebook_client || Facelink::FacebookClient.new
     end
 
-    def interactions()
+    def interactions
       interactions = []
       posts = facebook_client.posts(page_id, limit)
 
       posts.each do |post|
-        interactions += interactions_for(post, "reactions") + interactions_for(post, "comments")
+        interactions += interactions_for(post, 'reactions') + interactions_for(post, 'comments')
       end
 
       interactions
@@ -41,11 +39,11 @@ module Facelink
 
     def transform_data(data, post, interaction_type)
       data.map do |interaction|
-        formatted_data  = {
-          user_id: interaction["id"],
+        formatted_data = {
+          user_id: interaction['id'],
           page_id: page_id,
-          post_id: post["id"],
-          post_type: post["type"]
+          post_id: post['id'],
+          post_type: post['type']
         }
 
         formatted_data.merge(transform_data_for(interaction_type, interaction))
@@ -54,15 +52,13 @@ module Facelink
 
     def transform_data_for(interaction_type, interaction)
       case interaction_type
-      when "comments"
-        { user_id: interaction["from"]["id"], interaction_type: "comment" }
-      when "reactions"
-        { user_id: interaction["id"], interaction_type: "reaction", interaction_subtype: interaction["type"] }
+      when 'comments'
+        { user_id: interaction['from']['id'], interaction_type: 'comment' }
+      when 'reactions'
+        { user_id: interaction['id'], interaction_type: 'reaction', interaction_subtype: interaction['type'] }
       else
         {}
       end
     end
-
   end
-
 end

--- a/lib/facelink/config.rb
+++ b/lib/facelink/config.rb
@@ -14,7 +14,7 @@ module Facelink
       @config ||= YAML.load_file(File.expand_path(CONFIG_PATH))
     end
 
-    def configure_facebook_client
+    def configure_koala_facebook_client
       Koala.config.api_version = config["facebook"]["api_version"] || API_VERSION
     end
 

--- a/lib/facelink/config.rb
+++ b/lib/facelink/config.rb
@@ -2,11 +2,9 @@ require 'yaml'
 require 'koala'
 
 module Facelink
-
   module Config
-
-    CONFIG_PATH = '~/.facelink-config.yml'
-    API_VERSION = "v2.8"
+    CONFIG_PATH = '~/.facelink-config.yml'.freeze
+    API_VERSION = 'v2.8'.freeze
 
     module_function
 
@@ -15,19 +13,17 @@ module Facelink
     end
 
     def configure_koala_facebook_client
-      Koala.config.api_version = config["facebook"]["api_version"] || API_VERSION
+      Koala.config.api_version = config['facebook']['api_version'] || API_VERSION
     end
 
     def create_config_file(access_token, api_version = API_VERSION)
-      configuration = { "facebook" => { "access_token" => access_token, "api_version" => api_version } }
+      configuration = { 'facebook' => { 'access_token' => access_token, 'api_version' => api_version } }
 
       File.open(File.expand_path(CONFIG_PATH), 'w') { |f| f.write configuration.to_yaml }
     end
 
     def access_token
-     config["facebook"]["access_token"]
+      config['facebook']['access_token']
     end
-
   end
-
 end

--- a/lib/facelink/facebook_client.rb
+++ b/lib/facelink/facebook_client.rb
@@ -1,0 +1,25 @@
+require 'koala'
+
+module Facelink
+
+  class FacebookClient
+
+    attr_reader :client
+
+    def initialize
+      @client ||= Koala::Facebook::API.new(Facelink::Config.access_token)
+    end
+
+    def interactions_data_for(interaction_type)
+      Koala::Facebook::API::GraphCollection.new(interaction_type, client)
+    end
+
+    def posts(page_id, limit)
+      client.get_connections(page_id, "posts", { limit: limit,
+                                                 fields: ["reactions{id, type}",
+                                                          "comments{id, from}",
+                                                          "type"]})
+    end
+
+  end
+end

--- a/lib/facelink/facebook_client.rb
+++ b/lib/facelink/facebook_client.rb
@@ -1,9 +1,7 @@
 require 'koala'
 
 module Facelink
-
   class FacebookClient
-
     attr_reader :client
 
     def initialize
@@ -15,11 +13,10 @@ module Facelink
     end
 
     def posts(page_id, limit)
-      client.get_connections(page_id, "posts", { limit: limit,
-                                                 fields: ["reactions{id, type}",
-                                                          "comments{id, from}",
-                                                          "type"]})
+      client.get_connections(page_id, 'posts', limit: limit,
+                                               fields: ['reactions{id, type}',
+                                                        'comments{id, from}',
+                                                        'type'])
     end
-
   end
 end

--- a/lib/facelink/report.rb
+++ b/lib/facelink/report.rb
@@ -15,7 +15,7 @@ module Facelink
         CSV.foreach(file) do |row|
           page_id = row[0]
           limit = row[1]
-          interactions = Facelink::Client.new(page_id, limit).interactions
+          interactions = Facelink::Client.new(page_id, limit, Facelink::FacebookClient.new).interactions
           interactions.each { |interaction| csv << interaction.values }
         end
       end

--- a/lib/facelink/report.rb
+++ b/lib/facelink/report.rb
@@ -1,9 +1,7 @@
 require 'csv'
 
 module Facelink
-
   class Report
-
     attr_reader :file
 
     def initialize(file)
@@ -22,9 +20,8 @@ module Facelink
     end
 
     def filepath
-      input_file = File.basename(file.path, ".*")
+      input_file = File.basename(file.path, '.*')
       "#{File.dirname(file.path)}/#{input_file}-user-interactions.csv"
     end
   end
-
 end

--- a/spec/facelink/client_spec.rb
+++ b/spec/facelink/client_spec.rb
@@ -5,7 +5,7 @@ describe Facelink::Client do
   let(:page_id) { "305736219467790" }
   let(:client) { described_class.new(page_id, 2) }
 
-  before { Facelink::Config.configure_facebook_client }
+  before { Facelink::Config.configure_koala_facebook_client }
 
   describe "#interactions" do
     let(:facebook_data) { JSON.load(File.read(File.join("spec", "fixtures", "stagelink.json"))) }

--- a/spec/facelink/client_spec.rb
+++ b/spec/facelink/client_spec.rb
@@ -3,7 +3,8 @@ require "json"
 
 describe Facelink::Client do
   let(:page_id) { "305736219467790" }
-  let(:client) { described_class.new(page_id, 2) }
+  let(:facebook_client) { Facelink::FacebookClient.new }
+  let(:client) { described_class.new(page_id, 2, facebook_client) }
 
   before { Facelink::Config.configure_koala_facebook_client }
 
@@ -11,7 +12,7 @@ describe Facelink::Client do
     let(:facebook_data) { JSON.load(File.read(File.join("spec", "fixtures", "stagelink.json"))) }
 
     before do
-      allow_any_instance_of(Koala::Facebook::API).to receive(:get_connections).and_return(facebook_data)
+      allow_any_instance_of(Facelink::FacebookClient).to receive(:posts).and_return(facebook_data)
       allow_any_instance_of(Koala::Facebook::API::GraphCollection).to receive(:next_page).and_return(nil)
     end
 


### PR DESCRIPTION
It relates to #1. First step towards removing koala gem as dependency. 

The idea is to decouple the facelink client with the facebook client allowing the developer to use whatever facebook client he wants simply injecting when initializing. The clients should implement a common interface not defined yet.